### PR TITLE
Kill server child process

### DIFF
--- a/src/ap40.js
+++ b/src/ap40.js
@@ -114,9 +114,10 @@ const startServer = () => {
     console.error(`error server : ${dataErr}`);
   });
 
-  setTimeout(() => {
-    server.kill();
-  }, 60000);
+  server.kill('SIGINT');
+//   setTimeout(() => {
+//     server.kill();
+//   }, 60000);
 };
 
 /**


### PR DESCRIPTION
Using proc.kill('SIGINT'); to kill server child process without timeout